### PR TITLE
Added arduino-core & allow builds from docker-compose

### DIFF
--- a/raspberrypi_arm/Dockerfile
+++ b/raspberrypi_arm/Dockerfile
@@ -1,7 +1,7 @@
 FROM resin/rpi-raspbian
 MAINTAINER Geo VO <george.vo@alum.rpi.edu>
 
-RUN apt-get update && apt-get install -y build-essential python-dev python-pip git cron ed php5-fpm nginx
+RUN apt-get update && apt-get install -y build-essential python-dev python-pip git cron ed php5-fpm nginx arduino-core
 RUN pip install pyserial psutil simplejson configobj gitpython --upgrade
 RUN useradd -G www-data,dialout brewpi
 RUN bash -c "echo -e \"brewpi\nbrewpi\"|passwd brewpi"

--- a/raspberrypi_arm/README.md
+++ b/raspberrypi_arm/README.md
@@ -1,7 +1,7 @@
-These containers will only run on an ARM based system, such as a Raspberry Pi. 
+These containers will only run on an ARM based system, such as a Raspberry Pi.
 
 ### How to install Docker on your Pi
-As of this writing, the easiest way to get Docker on a Raspberry Pi is to use the Hypriot image. The base image can be found here: 
+As of this writing, the easiest way to get Docker on a Raspberry Pi is to use the Hypriot image. The base image can be found here:
 http://blog.hypriot.com/downloads/
 
 Once you have that running, you MUST do
@@ -11,17 +11,23 @@ apt-get update && apt-get install -y docker-hypriot docker-compose
 This will ensure you have Docker 1.10+ and Docker Compose 1.6+, required to use this docker-compose.yml file
 
 ### Running BrewPi via Docker on your Pi
-Once you have your Hypriot image running on your Pi, clone this repo, cd to either brewpi_single_container or brewpi_multi_container, and simply type 
+Once you have your Hypriot image running on your Pi, clone this repo, cd to either brewpi_single_container or brewpi_multi_container, and simply type
 ```
-docker-compose up
+docker-compose pull && docker-compose up
 ```
+
 If you wish to background these processes, just add a d!
 ```
-docker-compose up -d  
+docker-compose up -d
 ```
 For those of you using an Arduino (legacy code) instead of the newer Spark, you'll need to specify that by using
 ```
 system=arduino docker-compose up
+```
+
+If you want to rebuild your own brewpi image, you can
+```
+docker-compose build
 ```
 
 With that, you should be good to go! Happy Brewing!

--- a/raspberrypi_arm/docker-compose.yml
+++ b/raspberrypi_arm/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
   brewpi:
+    build: .
     image: vanosg/rpi-brewpi-omni:latest
     container_name: brewpi
     hostname: brewpi
@@ -13,6 +14,7 @@ services:
         - 80:80
     volumes:
         - ~/brewpi-data:/brewpi
+    restart: always
 
 networks:
     default:

--- a/x86_64/docker-compose.yml
+++ b/x86_64/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   brewpi:
     build: .
-    image: vanosg/rpi-brewpi-omni:latest
+    image: vanosg/brewpi-omni:latest
     container_name: brewpi
     hostname: brewpi
     environment:

--- a/x86_64/docker-compose.yml
+++ b/x86_64/docker-compose.yml
@@ -1,18 +1,20 @@
 version: '2'
 services:
   brewpi:
-    image: vanosg/brewpi-omni:latest
+    build: .
+    image: vanosg/rpi-brewpi-omni:latest
     container_name: brewpi
     hostname: brewpi
     environment:
         - system=$system
     devices:
         - "/dev/ttyACM0:/dev/ttyACM0"
-#        - "/dev/ttyAMA0:/dev/ttyAMA0"
+        #- "/dev/ttyAMA0:/dev/ttyAMA0"
     ports:
         - 80:80
     volumes:
         - ~/brewpi-data:/brewpi
+    restart: always
 
 networks:
     default:


### PR DESCRIPTION
Title says it all. The main thing is updating the dockerfile to install arduino-core, without it I was getting complains when flashing my arduino uno from the web interface. 

I've also changed the docker-compose file to allow building of the Dockerfile this behaviour unfortunately is non-customisable so doing `docker-compose up` will by default build the image rather than fetch (if the image doesn't exist). I've modified the README.md to reflect the new steps to prevent building for new users.

I've not done a thorough test of the docker-compose.yml alterations as building/fetching the images is _slow_ on the RPi B+ 
